### PR TITLE
Handle and print exceptions in conditionalrunner

### DIFF
--- a/conditionalrunner.py
+++ b/conditionalrunner.py
@@ -8,8 +8,8 @@ env = Environment(
 
 class ConditionalRunner:
     def __init__(self, template):
-        template_str = "".join(template)
-        self._template = env.from_string(template_str)
+        self._template_str = "".join(template)
+        self._template = env.from_string(self._template_str)
         self._ae = GlobalStorage().aircraft_events
         self._aq = GlobalStorage().aircraft_requests
 
@@ -52,7 +52,11 @@ class ConditionalRunner:
         GlobalStorage().encoders[index - 1].set_led_ring_value(int(value), blink)
 
     def execute(self):
-        self._template.render(data=self)
+        try:
+            self._template.render(data=self)
+        except Exception as e:
+            print('Exception during execution of template:', e)
+            print('For template:', self._template_str)
 
     def __call__(self, *args, **kwargs):
         self.execute()


### PR DESCRIPTION
Original problem that would stop the application:
```
Traceback (most recent call last):
  File "main.py", line 106, in <module>
    main_app(False)
  File "main.py", line 87, in main_app
    obj.on_simvar_data(sv)
  File "C:\Users\maart\Documents\dev\X-Touch-Mini-FS2020\trigger.py", line 26, in on_simvar_data
    self._event(False)
  File "C:\Users\maart\Documents\dev\X-Touch-Mini-FS2020\conditionalrunner.py", line 58, in __call__
    self.execute()
  File "C:\Users\maart\Documents\dev\X-Touch-Mini-FS2020\conditionalrunner.py", line 55, in execute
    self._template.render(data=self)
  File "C:\Users\maart\Documents\dev\X-Touch-Mini-FS2020\venv\lib\site-packages\jinja2\environment.py", line 1090, in render
    self.environment.handle_exception()
  File "C:\Users\maart\Documents\dev\X-Touch-Mini-FS2020\venv\lib\site-packages\jinja2\environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "C:\Users\maart\Documents\dev\X-Touch-Mini-FS2020\venv\lib\site-packages\jinja2\_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 1, in top-level template code
TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'

```

After fix:
```
Exception during execution of template: unsupported operand type(s) for /: 'NoneType' and 'float'
For template: {% set heading = (data.get_simvar_value('AUTOPILOT_HEADING_LOCK_DIR') / 27.0) | round %}{{ data.set_encoder_led_value(2, heading) }}
```