### PR TITLE
Allow simvar_led configuration for encoders

### DIFF
--- a/configfile.py
+++ b/configfile.py
@@ -93,6 +93,8 @@ class ConfigFile:
             event_press = elem.get('event_press')
             event_short_press = elem.get('event_short_press')
             event_long_press = elem.get('event_long_press')
+            simvar_led = elem.get('simvar_led')
+            mobiflightsimvar_led = elem.get('mobiflightsimvar_led')
             encoder = self._encoders[index - 1]
 
             if event_up and event_down:
@@ -107,6 +109,10 @@ class ConfigFile:
                 encoder.bind_short_press(self._create_binding(encoder, event_short_press))
             if event_long_press:
                 encoder.bind_long_press(self._create_binding(encoder, event_long_press))
+            if simvar_led:
+                encoder.bind_led_to_simvar(simvar_led)
+            if mobiflightsimvar_led:
+                encoder.bind_led_to_mobiflightsimvar(mobiflightsimvar_led)
 
     def _configure_buttons(self, data):
         for btn in self._buttons:

--- a/rotaryencoder.py
+++ b/rotaryencoder.py
@@ -10,6 +10,8 @@ class RotaryEncoder:
         self._receive_data_note = self._encoder_index - 1
         self._led_ring_value_cc = self._encoder_index + 8
         self._on_layer = ActiveLayerIdentifier.A
+        self._simvar = None
+        self._mobiflightsimvar = None
         self._event_up = None
         self._event_down = None
         self._alternate_event_up = None
@@ -49,6 +51,12 @@ class RotaryEncoder:
         self._current_led_ring_value = value
         self._update_led_ring()
 
+    def bind_led_to_simvar(self, simvar: str):
+        self._simvar = simvar
+
+    def bind_led_to_mobiflightsimvar(self, simvar: str):
+        self._mobiflightsimvar = simvar
+
     def bind_to_event(self, event_up, event_down):
         self._event_up = event_up
         self._event_down = event_down
@@ -67,6 +75,8 @@ class RotaryEncoder:
         self._event_press_long = event
 
     def reset_configuration(self):
+        self._simvar = None
+        self._mobiflightsimvar = None
         self._event_up = None
         self._event_down = None
         self._alternate_event_up = None
@@ -87,11 +97,11 @@ class RotaryEncoder:
 
     @property
     def bound_simvar(self):
-        return None
+        return self._simvar
 
     @property
     def bound_mobiflightsimvar(self):
-        return None
+        return self._mobiflightsimvar
 
 
     def on_cc_data(self, value):
@@ -133,6 +143,18 @@ class RotaryEncoder:
 
     def on_alternate_toggle(self, _):
         self._alternate_active = not self._alternate_active
+
+    def on_simvar_data(self, data):
+        if data == 1.0:
+            self.set_led_ring_on_off(True)
+        else:
+            self.set_led_ring_on_off(False)
+
+    def on_mobiflightsimvar_data(self, data):
+        if data == 1.0:
+            self.set_led_ring_on_off(True)
+        else:
+            self.set_led_ring_on_off(False)
 
     def _update_active_layer(self):
         ActiveLayer().active_layer = self._on_layer


### PR DESCRIPTION
Also allow the simple simvar and mobiflightsimvar led settings for encoders to turn on the whole led ring.

So that configurations like that are possible:
``` json
"encoders": [
    {
      "index": 5,
      "event_up": { "event": "A32NX.FCU_HDG_INC", "type": "manual", "value": 1 },
      "event_down": { "event": "A32NX.FCU_HDG_DEC", "type": "manual", "value": 1 },
      "event_short_press": { "event": "A32NX.FCU_HDG_PULL", "type": "manual", "value": 1 },
      "event_long_press":  { "event": "A32NX.FCU_HDG_PUSH", "type": "manual", "value": 1 },
      "mobiflightsimvar_led": "(L:A32NX_FCU_HDG_MANAGED_DOT)"
    },
    {
      "index": 6,
      "event_up": { "event": "A32NX.FCU_ALT_INC", "type": "manual", "value": 1 },
      "event_down": { "event": "A32NX.FCU_ALT_DEC", "type": "manual", "value": 1 },
      "event_short_press": { "event": "A32NX.FCU_ALT_PULL", "type": "manual", "value": 1 },
      "event_long_press":  { "event": "A32NX.FCU_ALT_PUSH", "type": "manual", "value": 1 },
      "mobiflightsimvar_led": "(L:A32NX_FCU_ALT_MANAGED)"
    },
```

