### PR TITLE
Improve aircraft matching

### DIFF
--- a/aircraftstaterequest.py
+++ b/aircraftstaterequest.py
@@ -1,0 +1,151 @@
+from SimConnect import *
+from SimConnect.Enum import *
+from SimConnect.Constants import *
+import time
+import ctypes
+from ctypes import *
+from ctypes.wintypes import *
+from MSFSPythonSimConnectMobiFlightExtension.src.simconnect_mobiflight import SimConnectMobiFlight
+
+class CustomSimconnect(SimConnectMobiFlight):
+    def __init__(self):
+        super().__init__()
+
+        # Workaround for Simconnect 0.4.24
+        self.dll.RequestSystemState.argtypes = [
+            HANDLE,
+            SIMCONNECT_DATA_REQUEST_ID,
+            c_char_p
+        ]
+    
+    def handle_state_event(self, ObjData):
+        dwRequestID = ObjData.dwRequestID
+        if dwRequestID in self.Requests:
+            _request = self.Requests[dwRequestID]
+            rtype = _request.definitions[0][1].decode()
+            if 'string' in rtype.lower():
+                pS = cast(ObjData.szString, c_char_p)
+                _request.outData = pS.value
+            else:
+                _request.outData = cast(
+                    ObjData.dwData, POINTER(c_double * len(_request.definitions))
+                ).contents[0]
+        else:
+            LOGGER.warn("Event ID: %d Not Handled." % (dwRequestID))
+
+class SysemStateRequest(object):
+
+    def get(self):
+        return self.value
+
+    def set(self, _value):
+        self.value = _value
+
+    @property
+    def value(self):
+        self.DATA_REQUEST_ID = self.sm.new_request_id()
+        self.outData = None
+        self.sm.Requests[self.DATA_REQUEST_ID.value] = self
+        if (self.LastData + self.time) < millis():
+            if self.get_sys_state_data(self):
+                self.LastData = millis()
+            else:
+                return None
+        return self.outData
+
+    def __init__(self, _deff, _sm, _time=10, _dec=None, _settable=False, _attemps=10):
+        self.DATA_DEFINITION_ID = None
+        self.definitions = []
+        self.description = _dec
+        self._name = None
+        self.definitions.append(_deff)
+        self.outData = None
+        self.attemps = _attemps
+        self.sm = _sm
+        self.time = _time
+        self.defined = False
+        self.settable = _settable
+        self.LastData = 0
+        self.LastID = 0
+
+    def request_sys_state_data(self, _Request):
+        _Request.outData = None
+        rtype = _Request.definitions[0][1].decode()
+        if 'string' in rtype.lower():
+            pyarr = bytearray(_Request.definitions[0][0])
+            dataarray = (ctypes.c_char * len(pyarr))(*pyarr)
+        else:
+            return
+
+        pStr = cast(
+            dataarray, c_char_p
+        )
+        
+        self.sm.dll.RequestSystemState(
+            self.sm.hSimConnect,
+            _Request.DATA_REQUEST_ID.value,
+            pStr
+        )
+        temp = DWORD(0)
+        self.sm.dll.GetLastSentPacketID(self.sm.hSimConnect, temp)
+        _Request.LastID = temp.value
+
+    def get_sys_state_data(self, _Request):
+        self.request_sys_state_data(_Request)
+        attemps = 0
+        while _Request.outData is None and attemps < _Request.attemps:
+            time.sleep(.01)
+            attemps += 1
+        if _Request.outData is None:
+            return False
+
+        return True
+
+class SystemStateRequestHelper:
+    def __init__(self, _sm, _time=10, _attemps=10):
+        self.sm = _sm
+        self.dic = []
+        self.time = _time
+        self.attemps = _attemps
+
+    def __getattr__(self, _name):
+        if _name in self.list:
+            key = self.list.get(_name)
+            setable = False
+            if key[3] == 'Y':
+                setable = True
+            ne = SysemStateRequest((key[1], key[2]), self.sm, _dec=key[0], _settable=setable, _time=self.time, _attemps=self.attemps)
+            setattr(self, _name, ne)
+            return ne
+        return None
+
+    def get(self, _name):
+        if getattr(self, _name) is None:
+            return None
+        return getattr(self, _name).value
+
+class SystemRequests():
+    def find(self, key):
+        if key in self.sysreq.list:
+            rqest = getattr(self.sysreq, key)
+            return rqest
+        return None
+
+    def get(self, key):
+        request = self.find(key)
+        if request is None:
+            return None
+        return request.value
+
+    def __init__(self, _sm, _time=10, _attemps=10):
+        self.sm = _sm
+        self.sysreq = self.__SystemStateRequest(_sm, _time, _attemps)
+    
+    class __SystemStateRequest(SystemStateRequestHelper):
+        list = {
+            "AIRCRAFT_LOADED": ["Requests the full path name of the last loaded aircraft flight dynamics file. These files have a .AIR extension.", b'AircraftLoaded', b'String', 'N'],
+            "DIALOG_MODE": ["Requests whether the simulation is in Dialog mode or not. ", b'DialogMode', b'String', 'N'],
+            "FLIGHT_LOADED": ["Requests the full path name of the last loaded flight. Flight files have the extension .FLT.", b'FlightLoaded', b'String', 'N'],
+            "FLIGHT_PLAN": ["Requests the full path name of the active flight plan. An empty string will be returned if there is no active flight plan.", b'FlightPlan', b'String', 'N'],
+            "SIM": ["Requests the state of the simulation. If 1 is returned, the user is in control of the aircraft, if 0 is returned, the user is navigating the UI.", b'Sim', b'String', 'N']
+        }

--- a/aircraftstaterequest.py
+++ b/aircraftstaterequest.py
@@ -1,14 +1,11 @@
-# Part of code adapted from https://github.com/odwdinc/Python-SimConnect licensed under GPLv3
-# Original Author: odwdinc
-# All rights belong to the original author
-
 from SimConnect import *
 from SimConnect.Enum import *
 from SimConnect.Constants import *
 import time
-import ctypes
 from ctypes import *
 from ctypes.wintypes import *
+
+from nbformat import current_nbformat
 from MSFSPythonSimConnectMobiFlightExtension.src.simconnect_mobiflight import SimConnectMobiFlight
 
 class CustomSimconnect(SimConnectMobiFlight):
@@ -26,130 +23,33 @@ class CustomSimconnect(SimConnectMobiFlight):
         dwRequestID = ObjData.dwRequestID
         if dwRequestID in self.Requests:
             _request = self.Requests[dwRequestID]
-            rtype = _request.definitions[0][1].decode()
-            if 'string' in rtype.lower():
-                pS = cast(ObjData.szString, c_char_p)
-                _request.outData = pS.value
-            else:
-                _request.outData = cast(
-                    ObjData.dwData, POINTER(c_double * len(_request.definitions))
-                ).contents[0]
+            _request.outData = cast(ObjData.szString, c_char_p).value
         else:
             LOGGER.warn("Event ID: %d Not Handled." % (dwRequestID))
 
 class SystemStateRequest(object):
+    def __init__(self, sm, attempts=10):
+        self._sm = sm
+        self._attempts = attempts
+        self._request_id = 0
 
-    def get(self):
-        return self.value
-
-    def set(self, _value):
-        self.value = _value
-
-    @property
-    def value(self):
-        self.DATA_REQUEST_ID = self.sm.new_request_id()
+        # Make it compatible with original Simconnect dispatcher
         self.outData = None
-        self.sm.Requests[self.DATA_REQUEST_ID.value] = self
-        if (self.LastData + self.time) < millis():
-            if self.get_sys_state_data(self):
-                self.LastData = millis()
-            else:
-                return None
-        return self.outData
-
-    def __init__(self, _deff, _sm, _time=10, _dec=None, _settable=False, _attemps=10):
-        self.DATA_DEFINITION_ID = None
-        self.definitions = []
-        self.description = _dec
-        self._name = None
-        self.definitions.append(_deff)
-        self.outData = None
-        self.attemps = _attemps
-        self.sm = _sm
-        self.time = _time
-        self.defined = False
-        self.settable = _settable
-        self.LastData = 0
         self.LastID = 0
 
-    def request_sys_state_data(self, _Request):
-        _Request.outData = None
-        rtype = _Request.definitions[0][1].decode()
-        if 'string' in rtype.lower():
-            pyarr = bytearray(_Request.definitions[0][0])
-            dataarray = (ctypes.c_char * len(pyarr))(*pyarr)
-        else:
-            return
+    def _request_system_state(self, szState):
+        p_szState = c_char_p(szState.encode())
+        self._request_id = self._sm.new_request_id().value
+        self._sm.Requests[self._request_id] = self
+        self._sm.dll.RequestSystemState(self._sm.hSimConnect, self._request_id, p_szState)
+        last_id_tmp = DWORD(0)
+        self._sm.dll.GetLastSentPacketID(self._sm.hSimConnect, last_id_tmp)
+        self.LastID = last_id_tmp.value
 
-        pStr = cast(
-            dataarray, c_char_p
-        )
-        
-        self.sm.dll.RequestSystemState(
-            self.sm.hSimConnect,
-            _Request.DATA_REQUEST_ID.value,
-            pStr
-        )
-        temp = DWORD(0)
-        self.sm.dll.GetLastSentPacketID(self.sm.hSimConnect, temp)
-        _Request.LastID = temp.value
-
-    def get_sys_state_data(self, _Request):
-        self.request_sys_state_data(_Request)
-        attemps = 0
-        while _Request.outData is None and attemps < _Request.attemps:
-            time.sleep(.01)
-            attemps += 1
-        if _Request.outData is None:
-            return False
-
-        return True
-
-class SystemStateRequestHelper:
-    def __init__(self, _sm, _time=10, _attemps=10):
-        self.sm = _sm
-        self.dic = []
-        self.time = _time
-        self.attemps = _attemps
-
-    def __getattr__(self, _name):
-        if _name in self.list:
-            key = self.list.get(_name)
-            setable = False
-            if key[3] == 'Y':
-                setable = True
-            ne = SystemStateRequest((key[1], key[2]), self.sm, _dec=key[0], _settable=setable, _time=self.time, _attemps=self.attemps)
-            setattr(self, _name, ne)
-            return ne
-        return None
-
-    def get(self, _name):
-        if getattr(self, _name) is None:
-            return None
-        return getattr(self, _name).value
-
-class SystemRequests():
-    def find(self, key):
-        if key in self.sysreq.list:
-            rqest = getattr(self.sysreq, key)
-            return rqest
-        return None
-
-    def get(self, key):
-        request = self.find(key)
-        if request is None:
-            return None
-        return request.value
-
-    def __init__(self, _sm, _time=10, _attemps=10):
-        self.sm = _sm
-        self.sysreq = self.__SystemStateRequest(_sm, _time, _attemps)
-    
-    class __SystemStateRequest(SystemStateRequestHelper):
-        list = {
-            "AIRCRAFT_LOADED": ["Requests the full path name of the last loaded aircraft flight dynamics file. These files have a .AIR extension.", b'AircraftLoaded', b'String', 'N'],
-            "DIALOG_MODE": ["Requests whether the simulation is in Dialog mode or not. ", b'DialogMode', b'String', 'N'],
-            "FLIGHT_LOADED": ["Requests the full path name of the last loaded flight. Flight files have the extension .FLT.", b'FlightLoaded', b'String', 'N'],
-            "FLIGHT_PLAN": ["Requests the full path name of the active flight plan. An empty string will be returned if there is no active flight plan.", b'FlightPlan', b'String', 'N'],
-            "SIM": ["Requests the state of the simulation. If 1 is returned, the user is in control of the aircraft, if 0 is returned, the user is navigating the UI.", b'Sim', b'String', 'N']
-        }
+    def get_system_state(self, szState):
+        current_attempt = 0
+        self._request_system_state(szState)
+        while current_attempt < self._attempts and self.outData is None:
+            time.sleep(0.1)
+            self._attempts += 1
+        return self.outData

--- a/aircraftstaterequest.py
+++ b/aircraftstaterequest.py
@@ -4,8 +4,6 @@ from SimConnect.Constants import *
 import time
 from ctypes import *
 from ctypes.wintypes import *
-
-from nbformat import current_nbformat
 from MSFSPythonSimConnectMobiFlightExtension.src.simconnect_mobiflight import SimConnectMobiFlight
 
 class CustomSimconnect(SimConnectMobiFlight):

--- a/aircraftstaterequest.py
+++ b/aircraftstaterequest.py
@@ -1,3 +1,7 @@
+# Part of code adapted from https://github.com/odwdinc/Python-SimConnect licensed under GPLv3
+# Original Author: odwdinc
+# All rights belong to the original author
+
 from SimConnect import *
 from SimConnect.Enum import *
 from SimConnect.Constants import *
@@ -33,7 +37,7 @@ class CustomSimconnect(SimConnectMobiFlight):
         else:
             LOGGER.warn("Event ID: %d Not Handled." % (dwRequestID))
 
-class SysemStateRequest(object):
+class SystemStateRequest(object):
 
     def get(self):
         return self.value
@@ -114,7 +118,7 @@ class SystemStateRequestHelper:
             setable = False
             if key[3] == 'Y':
                 setable = True
-            ne = SysemStateRequest((key[1], key[2]), self.sm, _dec=key[0], _settable=setable, _time=self.time, _attemps=self.attemps)
+            ne = SystemStateRequest((key[1], key[2]), self.sm, _dec=key[0], _settable=setable, _time=self.time, _attemps=self.attemps)
             setattr(self, _name, ne)
             return ne
         return None

--- a/configfile.py
+++ b/configfile.py
@@ -24,8 +24,14 @@ class ConfigFile:
             for elem in base_data['aircraft']:
                 aircraft_contains = elem['aircraft_contains']
                 file = elem['file']
-                if aircraft_contains in str(self._aircraft):
-                    config_file = file
+                if isinstance(aircraft_contains, list):
+                    for contain in aircraft_contains:
+                        if contain.lower() in self._aircraft:
+                            config_file = file
+                            break
+                else:
+                    if aircraft_contains.lower() in self._aircraft:
+                        config_file = file
             self._configure_additional_simvars(base_data)
             if 'automatic_layer_revert' in base_data:
                 GlobalStorage().active_layer_changer.enable_layer_revert_timer(base_data['automatic_layer_revert'])
@@ -191,3 +197,12 @@ class ConfigFile:
                 helper.list[elem['name']] = simvar_elem
             if helper not in self._aq.list:
                 self._aq.list.append(helper)
+
+    @staticmethod
+    def get_if_use_base_matching():
+        with open('Configurations/config.json') as base_json_file:
+            base_data = json.load(base_json_file)
+            if 'use_aircraft_base_matching' in base_data:
+                return base_data['use_aircraft_base_matching']
+            else:
+                return False

--- a/globalstorage.py
+++ b/globalstorage.py
@@ -9,7 +9,7 @@ from pushbutton import PushButton
 from trigger import Trigger
 from fader import Fader
 from activelayerchanger import ActiveLayerChanger
-from aircraftstaterequest import SystemRequests
+from aircraftstaterequest import SystemStateRequest
 
 class GlobalStorage(metaclass=Singleton):
     def __init__(self):
@@ -66,7 +66,7 @@ class GlobalStorage(metaclass=Singleton):
     def set_active_layer_changer(self, ac: ActiveLayerChanger):
         self._active_layer_changer = ac
 
-    def set_system_request(self, sq: SystemRequests):
+    def set_system_request(self, sq: SystemStateRequest):
         self._sq = sq
 
     def set_base_matching(self, base_matching: bool):
@@ -109,7 +109,7 @@ class GlobalStorage(metaclass=Singleton):
         return self._active_layer_changer
 
     @property
-    def system_requests(self) -> SystemRequests:
+    def system_requests(self) -> SystemStateRequest:
         return self._sq
 
     @property

--- a/globalstorage.py
+++ b/globalstorage.py
@@ -9,7 +9,7 @@ from pushbutton import PushButton
 from trigger import Trigger
 from fader import Fader
 from activelayerchanger import ActiveLayerChanger
-
+from aircraftstaterequest import SystemRequests
 
 class GlobalStorage(metaclass=Singleton):
     def __init__(self):
@@ -22,6 +22,8 @@ class GlobalStorage(metaclass=Singleton):
         self._vr = None
         self._global_variables = {}
         self._active_layer_changer = None  # type: ActiveLayerChanger
+        self._sq = None
+        self._base_matching = None
 
     def clear(self):
         self._buttons = []
@@ -64,6 +66,12 @@ class GlobalStorage(metaclass=Singleton):
     def set_active_layer_changer(self, ac: ActiveLayerChanger):
         self._active_layer_changer = ac
 
+    def set_system_request(self, sq: SystemRequests):
+        self._sq = sq
+
+    def set_base_matching(self, base_matching: bool):
+        self._base_matching = base_matching
+
     @property
     def encoders(self) -> List[RotaryEncoder]:
         return self._encoders
@@ -99,3 +107,11 @@ class GlobalStorage(metaclass=Singleton):
     @property
     def active_layer_changer(self) -> ActiveLayerChanger:
         return self._active_layer_changer
+
+    @property
+    def system_requests(self) -> SystemRequests:
+        return self._sq
+
+    @property
+    def base_matching(self) -> bool:
+        return self._base_matching

--- a/main.py
+++ b/main.py
@@ -78,14 +78,10 @@ def run_aircraft_configuration(global_storage: GlobalStorage):
                 aircraft_loaded = aircraft_loaded.decode().lower()
                 aircraft_cfg_loc = aircraft_loaded.find('aircraft.cfg')
                 aircraft = aircraft_loaded[aircraft_loaded.rfind('\\', 0, aircraft_cfg_loc - 1) + 1:aircraft_cfg_loc - 1]
-            else: 
-                aircraft = 'None'
         else:
-            aircraft = aq.get('TITLE')
-            if aircraft is not None:
-                aircraft = aircraft.decode().lower()
-            else:
-                aircraft = 'None'
+            aircraft_title = aq.get('TITLE')
+            if aircraft_title is not None:
+                aircraft = aircraft_title.decode().lower()
 
         if aircraft and aircraft != current_aircraft:
             print("Aircraft changed from", current_aircraft, "to", aircraft)

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from globalstorage import GlobalStorage
 from mocksimconnect import MockAircraftEvents, MockAircraftRequests
 from activelayerchanger import ActiveLayerChanger
 from midiconnection import MidiConnection
-from aircraftstaterequest import SystemRequests, CustomSimconnect
+from aircraftstaterequest import CustomSimconnect, SystemStateRequest
 
 
 def connect_to_simulator(offline: bool):
@@ -38,7 +38,7 @@ def initialize(global_storage: GlobalStorage,
         global_storage.set_aircraft_events(AircraftEvents(sm))
         global_storage.set_aircraft_requests(AircraftRequests(sm, _time=200, _attemps=20))
         global_storage.set_mobiflight_variable_requests(vr) # Add MobiFlight
-        sq = SystemRequests(sm, _time=200, _attemps=20)
+        sq = SystemStateRequest(sm)
         global_storage.set_system_request(sq)
     else:
         global_storage.set_aircraft_events(MockAircraftRequests())
@@ -73,7 +73,7 @@ def run_aircraft_configuration(global_storage: GlobalStorage):
     # and reads the simvars for loaded configuration
     while True:
         if base_matching:
-            aircraft_loaded = sq.get('AIRCRAFT_LOADED')
+            aircraft_loaded = sq.get_system_state('AircraftLoaded')
             if aircraft_loaded is not None:
                 aircraft_loaded = aircraft_loaded.decode().lower()
                 aircraft_cfg_loc = aircraft_loaded.find('aircraft.cfg')


### PR DESCRIPTION
I've added a new function that can match aircrafts by its base `aircraft.cfg` location. The `aircraft_contains` field in `config.json` can now be a list. The keywords in `aircraft_contains` is now case insensitive. Everything is fully compatible with previours configuration files. 

To use the new function, change the `aircraft_contains` to the base name of that aircraft (or a part of the base name) and add `"use_aircraft_base_matching": true` to the global configuration.

    "aircraft": [
      {
        "aircraft_contains": "FlyByWire_A320_NEO",
        "file": "config_a320.json"
      }
    ]

The base information for an aircraft can be found in the `aircraft.cfg` file under any livery folder for that aircraft. Or you can simply look at the output of the program. Something like this:

    [VARIATION]
    base_container = "..\FlyByWire_A320_NEO"

If for some reason you don't want to use base matching, you can also add more keywords to `aircraft_contains`.

    "aircraft": [
      {
        "aircraft_contains": ["a320", "a32nx", "fbw", "fly by wire"],
        "file": "config_a320.json"
      }
    ]

Note: I added a `CustomSimconnect` class since the request system state function is not currently available in the `Simconnect` package. It can be removed once it is added. I also added a workaround for `Simconnect` 0.4.24 since the field is not defined in 0.4.24. It is actually fixed in 0.4.25 but that version have a bug that prevents the program from running.