### PR TITLE
fix aircraft undefined at sim startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ def connect_to_simulator(offline: bool):
     while not is_connected and not offline:
         try:
             sm = CustomSimconnect()
+            print(f"Connected to simulator")
             is_connected = True
         except Exception:
             print(f"Connection to simulator not possible. Retry in {waiting_time}s.") 
@@ -68,6 +69,7 @@ def run_aircraft_configuration(global_storage: GlobalStorage):
     vr = global_storage.mobiflight_variable_requests
     sq = global_storage.system_requests
     current_aircraft = "None"
+    aircraft = ""
     base_matching = global_storage.base_matching
     # Main program loop which checks for aircraft change
     # and reads the simvars for loaded configuration

--- a/main.py
+++ b/main.py
@@ -14,14 +14,17 @@ from midiconnection import MidiConnection
 from aircraftstaterequest import CustomSimconnect, SystemStateRequest
 
 
+
 def connect_to_simulator(offline: bool):
+    start = time.time()
     sm = None
     is_connected = False
     waiting_time = 10
     while not is_connected and not offline:
         try:
             sm = CustomSimconnect()
-            print(f"Connected to simulator")
+            end = time.time()
+            print(f"Connected to simulator after {int(end-start)}s")
             is_connected = True
         except Exception:
             print(f"Connection to simulator not possible. Retry in {waiting_time}s.") 


### PR DESCRIPTION
if the program is running while the sim is starting up, simconnect connects but there is no initial aircraft, and the program would quit.